### PR TITLE
reduce number of decimals when checking equality to 1 in GD

### DIFF
--- a/R/gd_clean_data.R
+++ b/R/gd_clean_data.R
@@ -190,10 +190,10 @@ check_gd_input <- function(population,
     share_pop <- c(population[1], diff(population))
     share_wel <- c(welfare[1], diff(welfare))
 
-    assertthat::assert_that(sum(share_pop) == 1,
+    assertthat::assert_that(round(sum(share_pop), digits = 8) == 1,
                             msg = "Share of `population` does not sum up to 1")
 
-    assertthat::assert_that(sum(share_wel) == 1,
+    assertthat::assert_that(round(sum(share_wel), digits = 8) == 1,
                             msg = "Share of `welfare` does not sum up to 1")
 
     #--------- make sure  share of income is always increasing ---------


### PR DESCRIPTION
Hi guys @tonyfujs and @Aeilert , 

The previous version of `gd_clean_data` was failing because in the 17th decimal the sum was not equal to 1.  I decided to use 8 decimals for precision, but let me know if we should use other number for precision in tests. 

However, there is another problem in the namespace that was not generated with my code and I unfortunately don't know how to solve. So, I created this pull request, but I could not check that the package is working correctly. 

Best, 

```r
> load_all()
#> Loading wbpip
> document()
#> Updating wbpip documentation
#> Loading wbpip
#> Error: 'gd_GHI_2009_income' is not an exported object from 'namespace:wbpip'
> check()
#> Updating wbpip documentation
#> Loading wbpip
#> Error: 'gd_GHI_2009_income' is not an exported object from 'namespace:wbpip'
```

