### PR TITLE
Add package authors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,11 +2,29 @@ Package: wbpip
 Title: What the Package Does (One Line, Title Case)
 Version: 0.0.0.9000
 Authors@R: 
-    person(given = "First",
-           family = "Last",
-           role = c("aut", "cre"),
-           email = "first.last@example.com",
-           comment = c(ORCID = "YOUR-ORCID-ID"))
+    c(person(given = "Tony",
+            family = "Fujs",
+            role = c("aut", "cre"),
+            email = "tfujs@worldbank.org"),
+     person(given = "Aleksander",
+            family = "Eilertsen",
+            role = "aut",
+            email = "aeilertsen@worldbank.org"),
+     person(given = "R. Andrés",
+            family = "Castañeda",
+            role = "aut",
+            email = "acastanedaa@worldbank.org"),
+     person(given = "Ifeanyi",
+            family = "Nzegwu Edochie",
+            role = "aut",
+            email = "iedochie@worldbank.org"),
+     person(given = "Minh",
+            family = "Cong Nguyen",
+            role = "ctb",
+            email = "mnguyen3@worldbank.org"),
+     person(given = "World Bank",
+            role = "cph")
+     )
 Description: What the package does (one paragraph).
 License: MIT + file LICENSE
 Encoding: UTF-8


### PR DESCRIPTION
Hi @tonyfujs 

A very minor thing, but I ran in to a subtle issue with using `:::` across different packages (which are doing by using ` wbpip:::compute_predicted_mean` in `pipdm`. It turns out that RMD CHECK gives a warning for this unless the package maintainer is the same person. So I added a list of package authors to both repos, with you as a maintainer. 

See also: https://stat.ethz.ch/pipermail/r-devel/2013-August/067190.html 