### PR TITLE
Revert changes in #157

### DIFF
--- a/R/md_compute_poverty_stats.R
+++ b/R/md_compute_poverty_stats.R
@@ -20,6 +20,10 @@
 #' @keywords internal
 md_compute_poverty_stats <- function(welfare, weight, povline_lcu) {
 
+  o       <- order(welfare)
+  welfare <- welfare[o]
+  weight  <- weight[o]
+
   pov_status        <- (welfare < povline_lcu)
   relative_distance <- (1 - (welfare[pov_status] / povline_lcu))
   non_pov           <- rep(0, collapse::fsum(!pov_status))

--- a/tests/testthat/test-ag_compute_pip_stats.R
+++ b/tests/testthat/test-ag_compute_pip_stats.R
@@ -3,8 +3,8 @@ default_ppp <- list(rural = 3.039222, urban = 3.905400)
 area_pop    <- list(rural = 793935216, urban = 199949784 )
 requested_mean <- list(rural = 29.57366 * 12 / 365, urban = 56.34465 * 12 / 365)
 # unit test TO BE UPDATED
-skip("ag_compute_pip_stats has changed")
 test_that("ag_compute_pip_stats works", {
+  skip("ag_compute_pip_stats has changed")
   out <- ag_compute_pip_stats(welfare = ag_ex1$welfare,
                               povline = 1.9,
                               population = ag_ex1$weight,


### PR DESCRIPTION
Removal of sorting causes some unit tests to fail.