### PR TITLE
Use if else instead of ifelse

### DIFF
--- a/R/gd_compute_pip_stats_lb.R
+++ b/R/gd_compute_pip_stats_lb.R
@@ -46,7 +46,7 @@ gd_compute_pip_stats_lb <- function(welfare,
   # Boundary conditions (Why 4?)
   z_min <- requested_mean * derive_lb(0.001, A, B, C) + 4
   z_max <- requested_mean * derive_lb(0.980, A, B, C) - 4
-  z_min <- ifelse(z_min < 0, 0, z_min)
+  z_min <- if (z_min < 0) 0 else z_min
 
   results1 <- list(requested_mean, povline, z_min, z_max, ppp)
   names(results1) <- list("mean", "poverty_line", "z_min", "z_max", "ppp")
@@ -815,8 +815,8 @@ gd_compute_pov_gap_lb <- function(u, headcount, A, B, C) {
   pov_gap <- headcount - (u * value_at_lb(headcount, A, B, C))
   # REVIEW RATIONAL FOR THESE ADJUSTMENTS
   # Adjust Poverty gap
-  pov_gap <- ifelse(headcount < pov_gap, headcount - 0.00001, pov_gap)
-  pov_gap <- ifelse(pov_gap < 0, 0, pov_gap)
+  pov_gap <- if (headcount < pov_gap) headcount - 0.00001 else pov_gap
+  pov_gap <- if (pov_gap < 0) 0 else pov_gap
 
   return(pov_gap)
 }
@@ -853,8 +853,8 @@ gd_compute_pov_severity_lb <- function(u, headcount, pov_gap, A, B, C) {
   pov_gap_sq <- u1 * (2 * pov_gap - u1 * headcount) + A^2 * u^2 * (B^2 * beta1 - 2 * B * C * beta2 + C^2 * beta3)
   # REVIEW RATIONAL FOR THESE ADJUSTMENTS
   # Adjust Poverty severity
-  pov_gap_sq <- ifelse(pov_gap < pov_gap_sq, pov_gap - 0.00001, pov_gap_sq)
-  pov_gap_sq <- ifelse(pov_gap_sq < 0, 0, pov_gap_sq)
+  pov_gap_sq <- if (pov_gap < pov_gap_sq) pov_gap - 0.00001 else pov_gap_sq
+  pov_gap_sq <- if (pov_gap_sq < 0) 0 else pov_gap_sq
 
   return(pov_gap_sq)
 }
@@ -988,7 +988,7 @@ rtNewt <- function(mean, povline, A, B, C) {
     dx <- f / df
     rtnewt <- rtnewt - dx
     if ((x1 - rtnewt) * (rtnewt - x2) < 0) {
-      rtnewt <- ifelse(rtnewt < x1, 0.5 * (x2 - x), 0.5 * (x - x1))
+      rtnewt <- if (rtnewt < x1) { 0.5 * (x2 - x) } else { 0.5 * (x - x1) }
     } else {
       if (abs(dx) < xacc) {
         return(rtnewt)

--- a/R/gd_compute_pip_stats_lq.R
+++ b/R/gd_compute_pip_stats_lq.R
@@ -74,7 +74,7 @@ gd_compute_pip_stats_lq <- function(welfare,
   # Boundary conditions (Why 4?)
   z_min <- requested_mean * derive_lq(0.001, A, B, C) + 4
   z_max <- requested_mean * derive_lq(0.980, A, B, C) - 4
-  z_min <- ifelse(z_min < 0, 0, z_min)
+  z_min <- if (z_min < 0) 0 else z_min
 
   results1 <- list(requested_mean, povline, z_min, z_max, ppp)
   names(results1) <- list("mean", "poverty_line", "z_min", "z_max", "ppp")
@@ -288,8 +288,8 @@ gd_compute_gini_lq <- function(A, B, C, e, m, n, r) {
     # P.gi <- (e/2) - tmp1 - (tmp2 * log(abs(tmpnum/tmpden)) / sqrt(m))
   } else {
     tmp4 <- ((2 * m) + n) / r
-    tmp4 <- ifelse(tmp4 < -1, -1, tmp4)
-    tmp4 <- ifelse(tmp4 > 1, 1, tmp4)
+    tmp4 <- if (tmp4 < -1) -1 else tmp4
+    tmp4 <- if (tmp4 > 1) 1 else tmp4
 
     # Formula does not match with paper
     gini <- e2 + (tmp3 / (4 * m)) * e1 - (n * abs(e) / (4 * m)) + (tmp2 * (asin(tmp4) - asin(n / r)) / sqrt(-m))
@@ -316,7 +316,7 @@ value_at_lq <- function(x, A, B, C) {
   m <- (B^2) - (4 * A)
   n <- (2 * B * e) - (4 * C)
   temp <- (m * x^2) + (n * x) + (e^2)
-  temp <- ifelse(temp < 0, 0, temp)
+  temp <- if (temp < 0) 0 else temp
 
   # Solving the equation of the Lorenz curve
   estle <- -0.5 * ((B * x) + e + sqrt(temp))
@@ -558,7 +558,7 @@ gd_compute_poverty_stats_lq <- function(mean,
   headcount <- -(n + ((r * bu) / sqrt(bu^2 - m))) / (2 * m)
 
   tmp0 <- (m * headcount^2) + (n * headcount) + (e^2)
-  tmp0 <- ifelse(tmp0 < 0, 0, tmp0)
+  tmp0 <- if (tmp0 < 0) 0 else tmp0
   tmp0 <- sqrt(tmp0)
 
   # First derivative of the Lorenz curve

--- a/R/prod_gd_compute_pip_stats_lb.R
+++ b/R/prod_gd_compute_pip_stats_lb.R
@@ -47,7 +47,7 @@ prod_gd_compute_pip_stats_lb <- function(welfare,
   # Boundary conditions (Why 4?)
   z_min <- requested_mean * derive_lb(0.001, A, B, C) + 4
   z_max <- requested_mean * derive_lb(0.980, A, B, C) - 4
-  z_min <- ifelse(z_min < 0, 0, z_min)
+  z_min <- if (z_min < 0) 0 else z_min
 
   results1 <- list(requested_mean, povline, z_min, z_max, ppp)
   names(results1) <- list("mean", "poverty_line", "z_min", "z_max", "ppp")

--- a/R/prod_gd_compute_pip_stats_lq.R
+++ b/R/prod_gd_compute_pip_stats_lq.R
@@ -75,7 +75,7 @@ prod_gd_compute_pip_stats_lq <- function(welfare,
   # Boundary conditions (Why 4?)
   z_min <- requested_mean * derive_lq(0.001, A, B, C) + 4
   z_max <- requested_mean * derive_lq(0.980, A, B, C) - 4
-  z_min <- ifelse(z_min < 0, 0, z_min)
+  z_min <- if (z_min < 0) 0 else z_min
 
   results1 <- list(requested_mean, povline, z_min, z_max, ppp)
   names(results1) <- list("mean", "poverty_line", "z_min", "z_max", "ppp")


### PR DESCRIPTION
Hi @tonyfujs 

This is very minor, but I discovered several cases of calls to `ifelse` when it looks like the vector length is just one inside the `gd_* ` functions. Using `if else` instead is typically much faster,. 