### PR TITLE
Minor optimization of md_infer_poverty_line

### DIFF
--- a/R/md_infer_poverty_line.R
+++ b/R/md_infer_poverty_line.R
@@ -9,7 +9,6 @@
 #' @param weight numeric: A vector of weights.
 #' @param popshare numeric: Share of population for which the corresponding.
 #' quantile is desired. Default .5 (i.e., weighted median).
-#' @param na.rm logical: Set to TRUE to remove missing from computations.
 #' @param include logical: **TO BE DOCUMENTED**.
 #'
 #' @examples
@@ -27,10 +26,9 @@
 md_infer_poverty_line <- function(welfare,
                                   weight,
                                   popshare = .5,
-                                  na.rm = FALSE,
                                   include = FALSE) {
-  prob <- cumsum(weight) / sum(weight, na.rm = na.rm)
-  ps <- which(abs(prob - popshare) == min(abs(prob - popshare), na.rm = na.rm))
+  prob <- cumsum(weight) / sum(weight)
+  ps <- which.min(abs(prob - popshare))
 
   # Weighted mean with the next available value in order to
   # guarantee inclusion in poverty calculation

--- a/man/predict_request_year_mean.Rd
+++ b/man/predict_request_year_mean.Rd
@@ -47,26 +47,29 @@ corresponding survey year.
 predict_request_year_mean(
   survey_year = 2005,
   survey_mean = 2.0,
-  proxy = list(value0 = 1350, req_value = 1500))
+  proxy = list(value0 = 1350, req_value = 1500)
+)
 
 # Interpolate two surveys (monotonic)
 predict_request_year_mean(
   survey_year = c(2000, 2005),
   survey_mean = c(2.0, 3.0),
-  proxy = list(value0 = 1350, value1 = 1600, req_value = 1500))
+  proxy = list(value0 = 1350, value1 = 1600, req_value = 1500)
+)
 
 # Interpolate two surveys (non-monotonic)
 predict_request_year_mean(
   survey_year = c(2000, 2005),
   survey_mean = c(2.0, 3.0),
-  proxy = list(value0 = 1350, value1 = 1500, req_value = 1600))
+  proxy = list(value0 = 1350, value1 = 1500, req_value = 1600)
+)
 
 # Extrapolate a single survey (w/ decimal year)
 predict_request_year_mean(
   survey_year = 2000.3,
   survey_mean = 2.0,
-  proxy = list(value0 = c(1350, 1400), req_value = 1600))
-
+  proxy = list(value0 = c(1350, 1400), req_value = 1600)
+)
 }
 \references{
 Prydz, E. B., D. Jolliffe, C. Lakner, D. G. Mahler, P. Sangraula. 2019.

--- a/tests/testthat/test-md_infer_poverty_line.R
+++ b/tests/testthat/test-md_infer_poverty_line.R
@@ -57,3 +57,14 @@ test_that("md_infer_poverty_line() works in any point of the distribution", {
     # cat(paste("\nhc:", hc, "\nx :", x, "\n"))
   })
 })
+
+test_that("md_infer_poverty_line() correctly handle NAs", {
+  # NAs are not removed as they are supposed to have been removed earlier in
+  # the pipeline. Adding this unit test here to highlight the fact that this is
+  # expected behavior.
+  res <- md_infer_poverty_line(
+    welfare = rep(100, 10001),
+    weight = c(rep(1, 10000), NA))
+
+  expect_equal(res, NaN)
+})


### PR DESCRIPTION
* Replace which with which.min
* Get rid of unneded na.rm option

Closes #176. 


Benchmark results 

```Unit: microseconds
                                                         expr  min   lq     mean median   uq
 wbpip:::md_infer_poverty_line(1:2000, weight = rep(1, 2000)) 30.3 34.9 95.59104   36.8 50.5
        md_infer_poverty_line2(1:2000, weight = rep(1, 2000)) 15.2 17.5 28.12611   18.4 25.5
      max neval cld
 389996.5 10000   a
   8068.0 10000   a
   ```