### PR TITLE
Minor optimization of md_compute_poverty_stats

### DIFF
--- a/R/md_compute_poverty_stats.R
+++ b/R/md_compute_poverty_stats.R
@@ -22,13 +22,12 @@ md_compute_poverty_stats <- function(welfare, weight, povline_lcu) {
 
   pov_status <- (welfare < povline_lcu)
   relative_distance <- (1 - (welfare[pov_status] / povline_lcu))
-  non_pov <- rep(0, collapse::fsum(!pov_status))
+  weight_pov <- weight[pov_status]
+  weight_total <- sum(weight)
 
-  fgt0 <- collapse::fmean(x = pov_status, w = weight)
-
-  fgt1 <- collapse::fmean(x = c(relative_distance, non_pov), w = weight)
-
-  fgt2 <- collapse::fmean(x = c(relative_distance^2, non_pov), w = weight)
+  fgt0 <- sum(weight_pov) / weight_total
+  fgt1 <- sum(relative_distance * weight_pov) / weight_total
+  fgt2 <- sum(relative_distance^2 * weight_pov) / weight_total
 
   #--------- Watts index ---------
 
@@ -38,8 +37,9 @@ md_compute_poverty_stats <- function(welfare, weight, povline_lcu) {
   # watts              <- collapse::fmean(x = c(sensitive_distance, non_pov),
   #                                       w = weight[welfare > 0])
   #--------- Old Watts ---------
-  watts <- collapse::fsum(sensitive_distance * weight[welfare > 0 & pov_status]) /
-    collapse::fsum(weight)
+
+  watts <- sum(sensitive_distance * weight[welfare > 0 & pov_status]) /
+    weight_total
 
   # Handle cases where Watts is numeric(0)
   if (identical(watts, numeric(0))) {


### PR DESCRIPTION
@tonyfujs 

Here is a suggestion for a minor improvement for `md_compute_poverty_stats()`. Not that much, but could potentially add up. 

Some results for SOM 2017 and IND 2016, with different LCU poverty lines below. 

The function `md_compute_poverty_stats2` is the code I'm suggesting in the PR. 

My C++ function is probably not the best possible one, so I'm attaching that for reference. If you want to look at that as well.  

**Benchmark results:** 

``` r

> summary(som2017$welfare)
     Min.   1st Qu.    Median      Mean   3rd Qu.      Max. 
     23.5   17318.7   27086.6   35803.4   43390.1 2758961.8 

Unit: milliseconds
                                                              expr     min       lq      mean   median
  md_compute_poverty_stats(som2017$welfare, som2017$weight, 25000) 43.3151 60.29765  86.50359 73.27395
 md_compute_poverty_stats2(som2017$welfare, som2017$weight, 25000) 45.1111 59.10625  83.29527 76.96755
          md_pov_stats_cpp(som2017$welfare, som2017$weight, 25000) 61.0590 80.16260 107.01850 97.07970
        uq      max neval cld
  97.49215 342.2908   100  a 
  97.22415 365.1365   100  a 
 116.43465 436.9715   100   b

Unit: milliseconds
                                                              expr     min       lq     mean   median
  md_compute_poverty_stats(som2017$welfare, som2017$weight, 50000) 70.2108 91.53905 115.0967 108.7358
 md_compute_poverty_stats2(som2017$welfare, som2017$weight, 50000) 66.1708 83.75640 104.0430  93.3994
          md_pov_stats_cpp(som2017$welfare, som2017$weight, 50000) 80.6444 95.57540 119.1866 110.4960
       uq      max neval cld
 127.1898 578.7507   100   a
 110.2614 509.0919   100   a
 123.5926 554.0876   100   a
 
> summary(idn2016$welfare)
   Min. 1st Qu.  Median    Mean 3rd Qu.    Max. 
   2709   14481   22565   29953   35825 1644792 

Unit: milliseconds
                                                              expr      min        lq     mean   median
  md_compute_poverty_stats(idn2016$$welfare, idn2016$$weight, 14481)  99.0739 128.97795 154.0183 141.9821
 md_compute_poverty_stats2(idn2016$$welfare, idn2016$$weight, 14481)  71.6976  94.24735 118.7086 107.5220
          md_pov_stats_cpp(idn2016$$welfare, idn2016$$weight, 14481) 105.6648 119.77215 139.3686 130.1110
       uq      max neval cld
 170.9264 548.9688   100   b
 125.0330 566.5511   100  a 
 156.1805 216.2279   100   b 
 
 Unit: milliseconds
                                                                expr      min       lq     mean   median
  md_compute_poverty_stats(idn2016$welfare, idn2016$weight, 1644792) 197.7930 268.9720 378.2719 300.0316
 md_compute_poverty_stats2(idn2016$welfare, idn2017$weight, 1644792) 160.7031 255.7015 352.3161 283.7356
          md_pov_stats_cpp(idn2016$welfare, idn2016$weight, 1644792) 232.7135 283.7138 420.1502 352.1884
       uq      max neval cld
 399.6277 1891.900   100   a
 385.2088 1158.598   100   a
 439.7242 1743.482   100   a

```


**Custom C++:**



```r 
cppFunction('List md_pov_stats_cpp(NumericVector welfare, NumericVector weight, double povline_lcu) {

  LogicalVector pov_status;
  NumericVector welfare_pov;
  NumericVector weight_pov;
  double weight_total;
  NumericVector relative_distance;
  NumericVector relative_distance2;
  NumericVector w_gt_zero;
  NumericVector sensitive_distance;
  NumericVector weight_status;

  double fgt0;
  double fgt1;
  double fgt2;
  double watts;

  /* FGT stats */

  pov_status = (welfare < povline_lcu);
  welfare_pov = welfare[pov_status];
  weight_pov = weight[pov_status];
  weight_total = sum(weight);
  relative_distance = 1 - welfare_pov / povline_lcu;
  relative_distance2 = pow(relative_distance, 2);

  fgt0 = sum(weight_pov) / weight_total;
  fgt1 = sum(relative_distance * weight_pov) / weight_total;
  fgt2 = sum(relative_distance2 * weight_pov) / weight_total;

  /* Watts index */

  w_gt_zero = welfare[(welfare > 0) & pov_status];
  sensitive_distance = log(povline_lcu / w_gt_zero);
  weight_status = weight[(welfare > 0) & pov_status];

  watts = sum(sensitive_distance * weight_status) / sum(weight);

  return List::create(
    _["headcount"] = fgt0,
    _["poverty_gap"] = fgt1,
    _["poverty_severity"] = fgt2,
    _["watts"] = watts
  );

}')