### PR TITLE
MD dist / mld improvment

### DIFF
--- a/R/md_compute_dist_stats.R
+++ b/R/md_compute_dist_stats.R
@@ -44,8 +44,8 @@ md_compute_dist_stats <- function(welfare, weight,
 
   polarization <- md_compute_polarization(
     welfare = welfare, weight = weight,
-    gini = gini, weighted_mean = mean,
-    weighted_median = median
+    gini = gini, mean = mean,
+    median = median
   )
 
   return(list(

--- a/R/md_compute_dist_stats.R
+++ b/R/md_compute_dist_stats.R
@@ -5,7 +5,7 @@
 #'
 #' @param welfare numeric: A vector of income or consumption values.
 #' @param weight numeric: A vector of weights.
-#' @param mean numeric: A value with the mean. Optional.
+#' @param mean numeric: A value with the (weighted) mean. Optional.
 #' @param nbins numeric: number of points on the Lorenz curve.
 #' @param n_quantile numeric: Number of quantiles for which share of total
 #'   income is desired. It can't be larger that the total number of percentiles
@@ -20,8 +20,6 @@ md_compute_dist_stats <- function(welfare, weight,
                                   n_quantile = 10) {
   if (is.null(mean)) {
     mean <- collapse::fmean(x = welfare, w = weight)
-  } else {
-    mean <- mean
   }
 
   lorenz <- md_compute_lorenz(
@@ -40,7 +38,8 @@ md_compute_dist_stats <- function(welfare, weight,
   )
 
   mld <- md_compute_mld(
-    welfare = welfare, weight = weight
+    welfare = welfare, weight = weight,
+    mean = mean
   )
 
   polarization <- md_compute_polarization(

--- a/R/md_compute_mld.R
+++ b/R/md_compute_mld.R
@@ -3,23 +3,20 @@
 #' Given a vector of weights and welfare, this functions computes the
 #' Mean Log Deviation (MLD).
 #'
-#' @param welfare numeric: vector of welfare measures
-#' @param weight numeric: vector of weights
-#'
+#' @inheritParams md_compute_dist_stats
 #' @return numeric
-#'
 #' @examples
 #' wbpip:::md_compute_mld(welfare = 1:2000, weight = rep(1, 2000))
 #' @keywords internal
-md_compute_mld <- function(welfare, weight) {
+md_compute_mld <- function(welfare, weight, mean = NULL) {
 
   # Compute MLD
-  mean_welfare <- collapse::fmean(
-    x = welfare,
-    w = weight
-  )
+  if (is.null(mean)) {
+    mean <- collapse::fmean(x = welfare, w = weight)
+  }
+
   welfare[welfare <= 0] <- 1 # this should be done before the mean
-  deviation <- log(mean_welfare / welfare)
+  deviation <- log(mean / welfare)
   mld <- collapse::fmean(
     x = deviation,
     w = weight

--- a/R/md_compute_polarization.R
+++ b/R/md_compute_polarization.R
@@ -2,11 +2,9 @@
 #'
 #' Compute the Wolfson polarization index for microdata.
 #'
-#' @param welfare numeric: A vector of income or consumption values.
-#' @param weight numeric: A vector of weights.
+#' @inheritParams md_compute_dist_stats
 #' @param gini numeric: Gini. Output of [md_compute_gini()].
-#' @param weighted_mean numeric: Mean.
-#' @param weighted_median numeric: Median. Output of [md_compute_quantiles()].
+#' @param median numeric: Median. Output of [md_compute_quantiles()].
 #'
 #' @references
 #' Ravallion, M., S. Chen. 1996.
@@ -19,35 +17,34 @@
 #'   welfare = 1:2000,
 #'   weight = rep(1, 2000),
 #'   gini = 0.4,
-#'   weighted_mean = 950,
-#'   weighted_median = 1000
+#'   mean = 950,
+#'   median = 1000
 #' )
 #' @return numeric
 #' @keywords internal
 md_compute_polarization <- function(welfare, weight, gini,
-                                    weighted_mean,
-                                    weighted_median) {
+                                    mean, median) {
 
   # Calculate poverty stats (for headcount and poverty gap)
   pov_stats <- md_compute_poverty_stats(
     welfare = welfare,
     weight = weight,
-    povline_lcu = weighted_median
+    povline_lcu = median
   )
 
   # Calculate mean for the bottom 50 %
   mean_below50 <-
-    weighted_median *
+    median *
       (1 - (pov_stats$poverty_gap / pov_stats$headcount))
 
   # Calculate distribution corrected mean
-  dcm_mean <- (1 - gini) * weighted_mean
+  dcm_mean <- (1 - gini) * mean
 
   # Calculate Wolfson polaratisation index
   # Formula: W = 2 * (dcm - mean_b50) / median
   # dcm = distribution corrected mean
   # mean_b50 = the mean of the poorest half
-  polarization <- 2 * (dcm_mean - mean_below50) / weighted_median
+  polarization <- 2 * (dcm_mean - mean_below50) / median
 
   return(polarization)
 }

--- a/man/md_compute_dist_stats.Rd
+++ b/man/md_compute_dist_stats.Rd
@@ -17,7 +17,7 @@ md_compute_dist_stats(
 
 \item{weight}{numeric: A vector of weights.}
 
-\item{mean}{numeric: A value with the mean. Optional.}
+\item{mean}{numeric: A value with the (weighted) mean. Optional.}
 
 \item{nbins}{numeric: number of points on the Lorenz curve.}
 

--- a/man/md_compute_mld.Rd
+++ b/man/md_compute_mld.Rd
@@ -4,12 +4,14 @@
 \alias{md_compute_mld}
 \title{Mean Log Deviation}
 \usage{
-md_compute_mld(welfare, weight)
+md_compute_mld(welfare, weight, mean = NULL)
 }
 \arguments{
-\item{welfare}{numeric: vector of welfare measures}
+\item{welfare}{numeric: A vector of income or consumption values.}
 
-\item{weight}{numeric: vector of weights}
+\item{weight}{numeric: A vector of weights.}
+
+\item{mean}{numeric: A value with the (weighted) mean. Optional.}
 }
 \value{
 numeric

--- a/man/md_compute_polarization.Rd
+++ b/man/md_compute_polarization.Rd
@@ -4,7 +4,7 @@
 \alias{md_compute_polarization}
 \title{Wolfson polarization index}
 \usage{
-md_compute_polarization(welfare, weight, gini, weighted_mean, weighted_median)
+md_compute_polarization(welfare, weight, gini, mean, median)
 }
 \arguments{
 \item{welfare}{numeric: A vector of income or consumption values.}
@@ -13,9 +13,9 @@ md_compute_polarization(welfare, weight, gini, weighted_mean, weighted_median)
 
 \item{gini}{numeric: Gini. Output of \code{\link[=md_compute_gini]{md_compute_gini()}}.}
 
-\item{weighted_mean}{numeric: Mean.}
+\item{mean}{numeric: A value with the (weighted) mean. Optional.}
 
-\item{weighted_median}{numeric: Median. Output of \code{\link[=md_compute_quantiles]{md_compute_quantiles()}}.}
+\item{median}{numeric: Median. Output of \code{\link[=md_compute_quantiles]{md_compute_quantiles()}}.}
 }
 \value{
 numeric
@@ -28,8 +28,8 @@ wbpip:::md_compute_polarization(
   welfare = 1:2000,
   weight = rep(1, 2000),
   gini = 0.4,
-  weighted_mean = 950,
-  weighted_median = 1000
+  mean = 950,
+  median = 1000
 )
 }
 \references{

--- a/tests/testthat/test-md_compute_polarization.R
+++ b/tests/testthat/test-md_compute_polarization.R
@@ -31,8 +31,8 @@ test_that("md_compute_polarization() computations are correct", {
       welfare = df$welfare,
       weight = df$weight,
       gini = gini,
-      weighted_mean = weighted_mean,
-      weighted_median = weighted_median
+      mean = weighted_mean,
+      median = weighted_median
     )
     return(pol)
   })


### PR DESCRIPTION
`mld_compute_mld()` currently calculates the mean. There is no need to do this twice inside `md_compute_dist_stats()`, so I added an optional argument `mean = NULL`  that can be used parse the mean. We could also consider having this argument w/ any default value (similar to `md_compute_polarization()`), but think is good first (minimal effort) option. 