### PR TITLE
Simplify md_compute_lorenz()

### DIFF
--- a/R/md_compute_lorenz.R
+++ b/R/md_compute_lorenz.R
@@ -14,52 +14,43 @@
 #' @return data.frame
 #' @keywords internal
 md_compute_lorenz <- function(welfare, weight, nbins = NULL) {
+
   nobs <- length(weight)
   if (is.null(nbins)) {
     # Define number of points on the Lorenz curve
     if (nobs > 1000) nbins <- 100 else nbins <- 20
   }
 
-  # Placeholder for Lorenz curve
-  welfare_col <- vector(mode = "numeric", length = nbins)
-  lorenz_welfare <- vector(mode = "numeric", length = nbins)
-  lorenz_weight <- vector(mode = "numeric", length = nbins)
-
-  # Compute Lorenz curve
-  weighted_welfare <- weight * welfare
-  sum_weighted_welfare <- sum(weighted_welfare)
-  sum_weights <- sum(weight)
-  welfare_step <- sum_weights / nbins
-  next_level <- welfare_step
-  cum_weight <- 0 # Placeholder for cumulative weight
-  cum_welfare <- 0 # Placeholder for cumulative welfare
+  # Set initial parameters
+  cum_weight <- cumsum(weight)
+  welfare_step <- sum(weight) / nbins
+  # METHODOLOGY QUESTION: Should this hard coded 0.9999 be changed?
+  # Not sure why it is here... Most likely to handle some edge case. I tested
+  # the code without it, and it worked fine...
+  levels <- welfare_step * 1:nbins * 0.999999999
+  points <- vector("integer", nbins)
   j <- 1
 
-
+  # Create points vector
   for (i in seq_len(nobs)) {
-    cum_weight <- cum_weight + weight[i] # Cumulative weight
-    cum_welfare <- cum_welfare + weighted_welfare[i] # Cumulative income
-
-    while ((cum_weight >= next_level) & (j <= nbins)) {
-      welfare_col[j] <- welfare[i]
-      lorenz_welfare[j] <- cum_welfare / sum_weighted_welfare # Normalize cum_welfare
-      lorenz_weight[j] <- cum_weight / sum_weights # Normalize cum_weight
-
+    while ((cum_weight[i] >= levels[j]) & (j <= nbins)) {
+      points[j] <- i
       j <- j + 1
-      # METHODOLOGY QUESTION: Should this hard coded 0.9999 be changed?
-      # Not sure why it is here... Most likely to handle some edge case. I tested
-      # the code without it, and it worked fine...
-      if (j <= nbins) {
-        next_level <- welfare_step * j * 0.999999999
-      }
     }
   }
 
-  lorenz <- data.frame(
-    welfare        = welfare_col,
-    lorenz_welfare = lorenz_welfare,
-    lorenz_weight  = lorenz_weight
-  )
+  # Create Lorenz curve vectors
+  lorenz_welfare <- cumsum(welfare * weight) / sum(welfare * weight)
+  lorenz_weight <- cumsum(weight) / sum(weight)
 
-  return(lorenz)
+  # Select points on the Lorenz curve
+  welfare <- welfare[points]
+  lorenz_welfare <- lorenz_welfare[points]
+  lorenz_weight <- lorenz_weight[points]
+
+  return(data.frame(welfare,
+                    lorenz_welfare,
+                    lorenz_weight))
+
 }
+


### PR DESCRIPTION
Hi @tonyfujs 

I made an attempt to simplify and improve `md_compute_lorenz()`. I think this makes it more clear what's going on. But not sure that is actually better. Computation speed is marginally less, but memory allocation is higher. 

E.g. 

```r
data("md_ABC_2000_income")
df <- wbpip:::md_clean_data(md_ABC_2000_income,
                    welfare = 'welfare',
                    weight = 'weight')$data
 ```           


```
# A tibble: 2 x 13
  expression                                            min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
  <bch:expr>                                       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
1 wbpip:::md_compute_lorenz(df$welfare, df$weight)    782us   1.11ms      712.    18.2KB     2.86   996     4
2 md_compute_lorenz_3(df$welfare, df$weight)          806us  875.7us     1033.    82.5KB     5.19   995     5
```

```
Unit: microseconds
                                             expr   min     lq     mean median      uq     max neval cld
 wbpip:::md_compute_lorenz(df$welfare, df$weight) 842.2 929.25 1289.384 1005.5 1348.15 24203.3  1000   a
       md_compute_lorenz_3(df$welfare, df$weight) 821.5 907.35 1297.613  977.3 1232.10 36638.2  1000   a
```