### PR TITLE
fix value of poverty line with when Beta and quadratic are not normal

### DIFF
--- a/R/gd_select_lorenz.R
+++ b/R/gd_select_lorenz.R
@@ -315,8 +315,13 @@ retrieve_poverty <- function(lq,
                              max_poverty_gap = 0.9999998,
                              max_poverty_severity = 0.9999997) {
   if (!is_normal) {
+    if (lq$poverty_line == lb$poverty_line) {
+      pl <- lq$poverty_line
+    } else {
+      pl <- NA_real_
+    }
     return(list(
-      poverty_line     = NA_real_,
+      poverty_line     = pl,
       headcount        = NA_real_,
       poverty_gap      = NA_real_,
       poverty_severity = NA_real_,


### PR DESCRIPTION
Hi @tonyfujs , 

the PIP API is returning two values for alternative aggregate data (e.g., AFW) when one of the underlying group data tables does not mean normality in the poverty lines provided by the user. You can run the following and see that instead of one the API returns two. 

```r
lkups <- create_versioned_lkups(Sys.getenv("PIPAPI_DATA_ROOT_FOLDER_LOCAL"), 
                                vintage_pattern = "20220909")
lkup <- lkups$versions_paths[[lkups$latest_release]]

dt <- pip_grp_logic(
  country  = "AFW",
  year     = 1983,
  group_by = "wb",
  povline  = 6.85,
  lkup     = lkup, 
  censor = TRUE
)
dt[]

```

![image](https://user-images.githubusercontent.com/35301997/209017750-4c94470e-0424-4f06-8658-e70aa216dfbc.png)

Or, using `pipr`:
![image](https://user-images.githubusercontent.com/35301997/209019535-7777af06-8240-46ae-b733-a1cde85e41fd.png)


The problem is that in `wbpip` when neither the lorenz nor the quadratic meet normality, the value of the poverty line is set to `NA` in [this line](https://github.com/PIP-Technical-Team/wbpip/blob/263387f7b4021e6e98c590f3b2ea3344ccca2d2e/R/gd_select_lorenz.R#L319). Do you know is there is reason for that? I can understand the rationale behind making the estimates equal to `NA`, but I don't understand why the value of the poverty line should be set to `NA` as well. Since the poverty line is used as a _"byable"_ variable in `pipapi`, I think the problem should be fixed directly in `wbpip`. This PR fixes the problem, making sure the value of the poverty line in lorenz and quadratic is the same (which should be by construction). 

Thanks. 
