### PR TITLE
Md gini efficiency

### DIFF
--- a/R/md_compute_dist_stats.R
+++ b/R/md_compute_dist_stats.R
@@ -16,50 +16,57 @@
 #' wbpip:::md_compute_dist_stats(welfare = 1:2000, weight = rep(1, 2000))
 #' @return data.frame
 #' @keywords internal
-md_compute_dist_stats <- function(welfare, weight,
-                                  mean = NULL,
-                                  nbins = NULL,
-                                  lorenz = NULL,
+md_compute_dist_stats <- function(welfare,
+                                  weight,
+                                  mean       = NULL,
+                                  nbins      = NULL,
+                                  lorenz     = NULL,
                                   n_quantile = 10) {
   if (is.null(mean)) {
-    mean <- collapse::fmean(x = welfare, w = weight)
+    mean <- fmean(x = welfare,
+                  w = weight)
   }
 
   if (is.null(lorenz)) {
     lorenz <- md_compute_lorenz(
-      welfare = welfare, weight = weight,
-      nbins = nbins
+      welfare    = welfare,
+      weight     = weight,
+      nbins      = nbins
     )
   }
 
   quantiles <- md_compute_quantiles(
-    lwelfare = lorenz[["lorenz_welfare"]],
-    lweight = lorenz[["lorenz_weight"]],
-    percentile = lorenz[["welfare"]]
+    lwelfare     = lorenz[["lorenz_welfare"]],
+    lweight      = lorenz[["lorenz_weight"]],
+    percentile   = lorenz[["welfare"]]
   )
   median <- quantiles[["median"]]
 
   gini <- md_compute_gini(
-    welfare = welfare, weight = weight
+    welfare      = welfare,
+    weight       = weight
   )
 
   mld <- md_compute_mld(
-    welfare = welfare, weight = weight,
-    mean = mean
+    welfare      = welfare,
+    weight       = weight,
+    mean         = mean
   )
 
   polarization <- md_compute_polarization(
-    welfare = welfare, weight = weight,
-    gini = gini, mean = mean,
-    median = median
+    welfare      = welfare,
+    weight       = weight,
+    gini         = gini,
+    mean         = mean,
+    median       = median
   )
 
   return(list(
-    mean = mean,
-    median = median,
-    gini = gini,
+    mean         = mean,
+    median       = median,
+    gini         = gini,
     polarization = polarization,
-    mld = mld,
-    quantiles = quantiles[["quantiles"]]
+    mld          = mld,
+    quantiles    = quantiles[["quantiles"]]
   ))
 }

--- a/R/md_compute_gini.R
+++ b/R/md_compute_gini.R
@@ -7,23 +7,25 @@
 #'
 #' @inheritParams compute_pip_stats
 #' @examples
-#' wbpip:::md_compute_gini(welfare = 1:2000, weight = rep(1, 2000))
+#' md_compute_gini(welfare = 1:2000, weight = rep(1, 2000))
 #' @return numeric
 #' @export
 md_compute_gini <- function(welfare, weight) {
 
   # Compute weighted welfare
-  weighted_welfare <- welfare * weight
-  weighted_welfare_lag <- collapse::flag(weighted_welfare, fill = 0)
+  weighted_welfare     <- welfare * weight
+  weighted_welfare_lag <- flag(weighted_welfare,
+                               fill = 0)
 
   # Compute area under the curve using
   # Area of trapezoid = Base * Average height
-  v <- (cumsum(weighted_welfare_lag) + (weighted_welfare / 2)) * weight
-  auc <- sum(v) # Area Under the Curve
+  v   <- (fcumsum(weighted_welfare_lag) +
+             (weighted_welfare / 2)) * weight
+  auc <- fsum(v) # Area Under the Curve
 
   # Compute Area Under the Lorenz Curve
   # Normalize auc so it is always between 0 and 0.5
-  auc <- (auc / sum(weight)) / sum(weighted_welfare)
+  auc <- (auc / fsum(weight)) / fsum(weighted_welfare)
 
   # Compute Gini
   gini <- 1 - (2 * auc)


### PR DESCRIPTION
### Purpose
Small changes to the computation of the gini to make sure it uses `collapse`. 

The reasons for using `collapse` here: a) it works well with many object classes, allowing it to be used in `pipster`; b) it is more efficient. 
 
### Additional change
small change to `md_compute_dist_stats` to remove the `collapse::` because the package is already imported. 

### Other
All tests are passing. The results of the gini have not changed. 
