### PR TITLE
Add lorenz parameter to quantile functions

### DIFF
--- a/R/md_compute_quantiles.R
+++ b/R/md_compute_quantiles.R
@@ -188,23 +188,18 @@ md_compute_median <- function(welfare,
     )
   }
 
-  n      <- collapse::fnrow(lorenz)
-  median <- lorenz$welfare[n/2]
+  n  <- collapse::fnrow(lorenz)
 
-  if (!(n %% 2) == 0) {
-    n_upp  <- ceiling(n)/2
-    n_down <- floor(n)/2
-  #} else {
-    # median <- lorenz$welfare[length(lorenz$welfare + 1)/2]
-
-    welf2 <- lorenz$welfare[n_upp]
-    wei2  <- lorenz$weight[n_upp]
-    welf1 <- lorenz$welfare[n_down]
-    wei1  <- lorenz$weight[n_down]
-
-    median <- welf1 +
-      (welf2 - welf1)*(0.5 - wei1)/(wei2 - wei1)
-
+  if (n %% 2 == 0) {
+    median <- lorenz$welfare[n/2]
+  } else {
+    w1 <- lorenz$lorenz_weight[(n - 1)/2]
+    w2 <- lorenz$lorenz_weight[(n + 1)/2]
+    if (abs(0.5 - w1) < abs(0.5 - w2)) {
+      median <- lorenz$welfare[(n - 1)/2]
+    } else {
+      median <- lorenz$welfare[(n + 1)/2]
+    }
   }
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/R/md_compute_quantiles.R
+++ b/R/md_compute_quantiles.R
@@ -100,7 +100,7 @@ old_md_compute_quantiles <- function(lwelfare,
 #' @return list
 #' @keywords internal
 md_compute_quantiles_share <- function( welfare,
-                                        weight,
+                                        weight = rep(1, length(welfare)),
                                         n_quantile = 10,
                                         lorenz     = NULL){
   # # deal with NAs -----
@@ -173,7 +173,7 @@ md_compute_quantiles_share <- function( welfare,
 #' md_compute_quantiles(welfare = 1:2000, weight = rep(1, 2000))
 #' @keywords internal
 md_compute_quantiles <- function( welfare,
-                                  weight,
+                                  weight = rep(1, length(welfare)),
                                   n_quantile = 10,
                                   lorenz = NULL) {
 
@@ -211,7 +211,7 @@ md_compute_quantiles <- function( welfare,
 #' md_compute_median(welfare = 1:2000, weight = rep(1, 2000))
 #' @keywords internal
 md_compute_median <- function(welfare,
-                              weight,
+                              weight = rep(1, length(welfare)),
                               lorenz = NULL) {
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -265,7 +265,7 @@ md_compute_median <- function(welfare,
 #' @return list
 #' @keywords internal
 md_compute_quantiles_c <- function(welfare,
-                                    weight,
+                                    weight = rep(1, length(welfare)),
                                     n_quantile = 10) {
   # deal with NAs -----
   if (anyNA(welfare)) {

--- a/R/md_compute_quantiles.R
+++ b/R/md_compute_quantiles.R
@@ -98,9 +98,10 @@ old_md_compute_quantiles <- function(lwelfare,
 #'
 #' @return list
 #' @keywords internal
-md_compute_quantiles_share <- function(welfare,
+md_compute_quantiles_share <- function( welfare,
                                         weight,
-                                        n_quantile = 10){
+                                        n_quantile = 10,
+                                        lorenz     = NULL){
   # # deal with NAs -----
   # if (anyNA(welfare)) {
   #   ina      <- !is.na(welfare)
@@ -115,10 +116,16 @@ md_compute_quantiles_share <- function(welfare,
   # }
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  # Compute Lorenz   ---------
+  # Compute Lorenz if NULL  ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  lz <- md_compute_lorenz(welfare, weight, nbins = n_quantile)
+  if (is.null(lorenz)) {
+    lorenz <- md_compute_lorenz(
+      welfare    = welfare,
+      weight     = weight,
+      nbins      = n_quantile
+    )
+  }
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Compute share with quantile function and collapse   ---------
@@ -140,7 +147,7 @@ md_compute_quantiles_share <- function(welfare,
   # Compute share with lorenz   ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  share_quant <- diff(c(0,lz$lorenz_welfare))
+  share_quant <- diff(c(0,lorenz$lorenz_welfare))
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Return   ---------
@@ -163,15 +170,23 @@ md_compute_quantiles_share <- function(welfare,
 #' @examples
 #' md_compute_quantiles(welfare = 1:2000, weight = rep(1, 2000))
 #' @keywords internal
-md_compute_quantiles <- function(welfare,
+md_compute_quantiles <- function( welfare,
                                   weight,
-                                  n_quantile = 10) {
+                                  n_quantile = 10,
+                                  lorenz = NULL) {
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # computations   ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  lz        <- md_compute_lorenz(welfare, weight, nbins = n_quantile)
-  quantiles <- lz$welfare
+  if (is.null(lorenz)) {
+    lorenz <- md_compute_lorenz(
+      welfare    = welfare,
+      weight     = weight,
+      nbins      = n_quantile
+    )
+  }
+
+  quantiles <- lorenz$welfare
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Return   ---------

--- a/R/md_compute_quantiles.R
+++ b/R/md_compute_quantiles.R
@@ -207,25 +207,42 @@ md_compute_quantiles <- function( welfare,
 #' md_compute_median(welfare = 1:2000, weight = rep(1, 2000))
 #' @keywords internal
 md_compute_median <- function(welfare,
-                                 weight) {
-  # deal with NAs -----
-  if (anyNA(welfare)) {
-    ina      <- !is.na(welfare)
-    weight   <- weight[ina]
-    welfare  <- as.numeric(welfare)[ina]
-  }
-
-  if (anyNA(weight)) {
-    ina      <- !is.na(weight)
-    weight   <- weight[ina]
-    welfare  <- as.numeric(welfare)[ina]
-  }
+                              weight,
+                              lorenz = NULL) {
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # computations   ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  median <- collapse::fmedian(welfare, w = weight)
+  #median <- collapse::fmedian(df$welfare, w = df$weight)
+
+  if (is.null(lorenz)) {
+
+    # deal with NAs -----
+    if (anyNA(welfare)) {
+      ina      <- !is.na(welfare)
+      weight   <- weight[ina]
+      welfare  <- as.numeric(welfare)[ina]
+    }
+
+    if (anyNA(weight)) {
+      ina      <- !is.na(weight)
+      weight   <- weight[ina]
+      welfare  <- as.numeric(welfare)[ina]
+    }
+
+    lorenz <- md_compute_lorenz(
+      welfare    = welfare,
+      weight     = weight,
+      nbins      = 10
+    )
+  }
+
+  if ((length(lorenz$welfare) %% 2) == 0){
+    median <- lorenz$welfare[length(lorenz$welfare)/2]
+  }else{
+    median <- lorenz$welfare[(length(lorenz$welfare)+1)/2]
+  }
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Return   ---------

--- a/R/md_compute_quantiles.R
+++ b/R/md_compute_quantiles.R
@@ -93,8 +93,9 @@ old_md_compute_quantiles <- function(lwelfare,
 #' @param welfare numeric: A vector of income or consumption values.
 #' @param weight numeric: A vector of weights. Default is a vector of ones
 #' @param n_quantile numeric: Number of quantiles for which share of total income
-#' is desired. It can't be larger that the total number of percentiles in the
-#' Lorenz curve provided by the user.  default is 10.
+#' is desired. Default is 10.
+#' @param lorenz numeric: A vector with the Lorenz curve percentiles. It can be computed
+#' using the function `md_compute_lorenz`
 #'
 #' @return list
 #' @keywords internal
@@ -161,8 +162,9 @@ md_compute_quantiles_share <- function( welfare,
 #' @param welfare numeric: A vector of income or consumption values.
 #' @param weight numeric: A vector of weights. Default is a vector of ones,
 #' @param n_quantiles numeric: Number of quantiles for which share of total income
-#' is desired. It can't be larger that the total number of percentiles in the
-#' Lorenz curve provided by the user.  default is 10.
+#' is desired. Default is 10.
+#' @param lorenz numeric: A vector with the Lorenz curve percentiles. It can be computed
+#' using the function `md_compute_lorenz`
 #'
 #' @return list
 #' @export
@@ -199,6 +201,8 @@ md_compute_quantiles <- function( welfare,
 #'
 #' @param welfare numeric: A vector of income or consumption values.
 #' @param weight numeric: A vector of weights. Default is a vector of ones
+#' @param lorenz numeric: A vector with the Lorenz curve percentiles. It can be computed
+#' using the function `md_compute_lorenz`
 #'
 #' @return numeric
 #' @export
@@ -256,8 +260,7 @@ md_compute_median <- function(welfare,
 #' @param welfare numeric: A vector of income or consumption values.
 #' @param weight numeric: A vector of weights. Default is a vector of ones,
 #' @param n_quantiles numeric: Number of quantiles for which share of total income
-#' is desired. It can't be larger that the total number of percentiles in the
-#' Lorenz curve provided by the user.  default is 10.
+#' is desired. Default is 10.
 #'
 #' @return list
 #' @keywords internal

--- a/R/md_compute_quantiles.R
+++ b/R/md_compute_quantiles.R
@@ -94,8 +94,7 @@ old_md_compute_quantiles <- function(lwelfare,
 #' @param weight numeric: A vector of weights. Default is a vector of ones
 #' @param n_quantile numeric: Number of quantiles for which share of total income
 #' is desired. Default is 10.
-#' @param lorenz numeric: A vector with the Lorenz curve percentiles. It can be computed
-#' using the function `md_compute_lorenz`
+#' @param lorenz numeric: Output from `md_compute_lorenz`
 #'
 #' @return list
 #' @keywords internal
@@ -163,8 +162,7 @@ md_compute_quantiles_share <- function( welfare,
 #' @param weight numeric: A vector of weights. Default is a vector of ones,
 #' @param n_quantiles numeric: Number of quantiles for which share of total income
 #' is desired. Default is 10.
-#' @param lorenz numeric: A vector with the Lorenz curve percentiles. It can be computed
-#' using the function `md_compute_lorenz`
+#' @param lorenz numeric: Output from `md_compute_lorenz`
 #'
 #' @return list
 #' @export
@@ -201,8 +199,7 @@ md_compute_quantiles <- function( welfare,
 #'
 #' @param welfare numeric: A vector of income or consumption values.
 #' @param weight numeric: A vector of weights. Default is a vector of ones
-#' @param lorenz numeric: A vector with the Lorenz curve percentiles. It can be computed
-#' using the function `md_compute_lorenz`
+#' @param lorenz numeric: Output from `md_compute_lorenz`
 #'
 #' @return numeric
 #' @export

--- a/R/md_compute_quantiles.R
+++ b/R/md_compute_quantiles.R
@@ -98,61 +98,29 @@ old_md_compute_quantiles <- function(lwelfare,
 #'
 #' @return list
 #' @keywords internal
-md_compute_quantiles_share <- function( welfare,
-                                        weight = rep(1, length(welfare)),
-                                        n_quantile = 10,
-                                        lorenz     = NULL){
-  # # deal with NAs -----
-  # if (anyNA(welfare)) {
-  #   ina      <- !is.na(welfare)
-  #   weight   <- weight[ina]
-  #   welfare  <- as.numeric(welfare)[ina]
-  # }
-  #
-  # if (anyNA(weight)) {
-  #   ina      <- !is.na(weight)
-  #   weight   <- weight[ina]
-  #   welfare  <- as.numeric(welfare)[ina]
-  # }
-
+md_compute_quantiles_share <- function(welfare    = NULL,
+                                       weight     = rep(1, length(welfare)),
+                                       n_quantile = 10,
+                                       lorenz     = NULL){
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Compute Lorenz if NULL  ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  if (is.null(lorenz)) {
-    lorenz <- md_compute_lorenz(
-      welfare    = welfare,
-      weight     = weight,
-      nbins      = n_quantile
-    )
+  if (is.null(lorenz) ||
+      !n_quantile == nrow(lorenz)) {
+    lorenz <- md_compute_lorenz(welfare = welfare,
+                                weight  = weight,
+                                nbins   = n_quantile)
   }
-
-  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  # Compute share with quantile function and collapse   ---------
-  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  # qnt <- md_compute_quantiles_c(welfare, weight, n_quantile)
-  #
-  # cum_share <- vector("numeric",n_quantile)
-  #
-  # for (i in seq_len(n_quantile)){
-  #   qnt_i <- qnt[i]
-  #   cum_share[i] <- fsum(welfare[welfare<=qnt_i],
-  #                          w = weight[welfare<=qnt_i]) / fsum(welfare, w = weight)
-  # }
-  #
-  # share_quant <- diff(c(0,cum_share))
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Compute share with lorenz   ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  share_quant <- diff(c(0,lorenz$lorenz_welfare))
+  share_quant <- diff(c(0, lorenz$lorenz_welfare))
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Return   ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  return(share_quant = share_quant)
+  share_quant
 
 }
 
@@ -170,28 +138,26 @@ md_compute_quantiles_share <- function( welfare,
 #' @examples
 #' md_compute_quantiles(welfare = 1:2000, weight = rep(1, 2000))
 #' @keywords internal
-md_compute_quantiles <- function( welfare,
-                                  weight = rep(1, length(welfare)),
-                                  n_quantile = 10,
-                                  lorenz = NULL) {
+md_compute_quantiles <- function(welfare    = NULL,
+                                 weight     = rep(1, length(welfare)),
+                                 n_quantile = 10,
+                                 lorenz     = NULL) {
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # computations   ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  if (is.null(lorenz)) {
-    lorenz <- md_compute_lorenz(
-      welfare    = welfare,
-      weight     = weight,
-      nbins      = n_quantile
-    )
+  if (is.null(lorenz) ||
+      !n_quantile == nrow(lorenz)) {
+    lorenz <- md_compute_lorenz(welfare = welfare,
+                                weight  = weight,
+                                nbins   = n_quantile)
   }
-
   quantiles <- lorenz$welfare
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Return   ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  return(quantiles = quantiles)
+  quantiles
 
 }
 
@@ -214,24 +180,7 @@ md_compute_median <- function(welfare,
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # computations   ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  #median <- collapse::fmedian(df$welfare, w = df$weight)
-
   if (is.null(lorenz)) {
-
-    # deal with NAs -----
-    if (anyNA(welfare)) {
-      ina      <- !is.na(welfare)
-      weight   <- weight[ina]
-      welfare  <- as.numeric(welfare)[ina]
-    }
-
-    if (anyNA(weight)) {
-      ina      <- !is.na(weight)
-      weight   <- weight[ina]
-      welfare  <- as.numeric(welfare)[ina]
-    }
-
     lorenz <- md_compute_lorenz(
       welfare    = welfare,
       weight     = weight,
@@ -239,16 +188,29 @@ md_compute_median <- function(welfare,
     )
   }
 
-  if ((length(lorenz$welfare) %% 2) == 0){
-    median <- lorenz$welfare[length(lorenz$welfare)/2]
-  }else{
-    median <- lorenz$welfare[(length(lorenz$welfare)+1)/2]
+  n      <- collapse::fnrow(lorenz)
+  median <- lorenz$welfare[n/2]
+
+  if (!(n %% 2) == 0) {
+    n_upp  <- ceiling(n)/2
+    n_down <- floor(n)/2
+  #} else {
+    # median <- lorenz$welfare[length(lorenz$welfare + 1)/2]
+
+    welf2 <- lorenz$welfare[n_upp]
+    wei2  <- lorenz$weight[n_upp]
+    welf1 <- lorenz$welfare[n_down]
+    wei1  <- lorenz$weight[n_down]
+
+    median <- welf1 +
+      (welf2 - welf1)*(0.5 - wei1)/(wei2 - wei1)
+
   }
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Return   ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  return(median = median)
+  median
 
 }
 

--- a/man/md_compute_median.Rd
+++ b/man/md_compute_median.Rd
@@ -4,15 +4,14 @@
 \alias{md_compute_median}
 \title{Compute median for microdata}
 \usage{
-md_compute_median(welfare, weight, lorenz = NULL)
+md_compute_median(welfare, weight = rep(1, length(welfare)), lorenz = NULL)
 }
 \arguments{
 \item{welfare}{numeric: A vector of income or consumption values.}
 
 \item{weight}{numeric: A vector of weights. Default is a vector of ones}
 
-\item{lorenz}{numeric: A vector with the Lorenz curve percentiles. It can be computed
-using the function \code{md_compute_lorenz}}
+\item{lorenz}{numeric: Output from \code{md_compute_lorenz}}
 }
 \value{
 numeric

--- a/man/md_compute_median.Rd
+++ b/man/md_compute_median.Rd
@@ -4,12 +4,15 @@
 \alias{md_compute_median}
 \title{Compute median for microdata}
 \usage{
-md_compute_median(welfare, weight)
+md_compute_median(welfare, weight, lorenz = NULL)
 }
 \arguments{
 \item{welfare}{numeric: A vector of income or consumption values.}
 
 \item{weight}{numeric: A vector of weights. Default is a vector of ones}
+
+\item{lorenz}{numeric: A vector with the Lorenz curve percentiles. It can be computed
+using the function \code{md_compute_lorenz}}
 }
 \value{
 numeric

--- a/man/md_compute_quantiles.Rd
+++ b/man/md_compute_quantiles.Rd
@@ -4,15 +4,19 @@
 \alias{md_compute_quantiles}
 \title{Compute quantiles for microdata with lorenz function}
 \usage{
-md_compute_quantiles(welfare, weight, n_quantile = 10, lorenz = NULL)
+md_compute_quantiles(
+  welfare,
+  weight = rep(1, length(welfare)),
+  n_quantile = 10,
+  lorenz = NULL
+)
 }
 \arguments{
 \item{welfare}{numeric: A vector of income or consumption values.}
 
 \item{weight}{numeric: A vector of weights. Default is a vector of ones,}
 
-\item{lorenz}{numeric: A vector with the Lorenz curve percentiles. It can be computed
-using the function \code{md_compute_lorenz}}
+\item{lorenz}{numeric: Output from \code{md_compute_lorenz}}
 
 \item{n_quantiles}{numeric: Number of quantiles for which share of total income
 is desired. Default is 10.}

--- a/man/md_compute_quantiles.Rd
+++ b/man/md_compute_quantiles.Rd
@@ -4,16 +4,18 @@
 \alias{md_compute_quantiles}
 \title{Compute quantiles for microdata with lorenz function}
 \usage{
-md_compute_quantiles(welfare, weight, n_quantile = 10)
+md_compute_quantiles(welfare, weight, n_quantile = 10, lorenz = NULL)
 }
 \arguments{
 \item{welfare}{numeric: A vector of income or consumption values.}
 
 \item{weight}{numeric: A vector of weights. Default is a vector of ones,}
 
+\item{lorenz}{numeric: A vector with the Lorenz curve percentiles. It can be computed
+using the function \code{md_compute_lorenz}}
+
 \item{n_quantiles}{numeric: Number of quantiles for which share of total income
-is desired. It can't be larger that the total number of percentiles in the
-Lorenz curve provided by the user.  default is 10.}
+is desired. Default is 10.}
 }
 \value{
 list

--- a/man/md_compute_quantiles_c.Rd
+++ b/man/md_compute_quantiles_c.Rd
@@ -12,8 +12,7 @@ md_compute_quantiles_c(welfare, weight, n_quantile = 10)
 \item{weight}{numeric: A vector of weights. Default is a vector of ones,}
 
 \item{n_quantiles}{numeric: Number of quantiles for which share of total income
-is desired. It can't be larger that the total number of percentiles in the
-Lorenz curve provided by the user.  default is 10.}
+is desired. Default is 10.}
 }
 \value{
 list

--- a/man/md_compute_quantiles_c.Rd
+++ b/man/md_compute_quantiles_c.Rd
@@ -4,7 +4,11 @@
 \alias{md_compute_quantiles_c}
 \title{Compute quantiles for microdata with collapse}
 \usage{
-md_compute_quantiles_c(welfare, weight, n_quantile = 10)
+md_compute_quantiles_c(
+  welfare,
+  weight = rep(1, length(welfare)),
+  n_quantile = 10
+)
 }
 \arguments{
 \item{welfare}{numeric: A vector of income or consumption values.}

--- a/man/md_compute_quantiles_share.Rd
+++ b/man/md_compute_quantiles_share.Rd
@@ -4,7 +4,7 @@
 \alias{md_compute_quantiles_share}
 \title{Compute quantiles share}
 \usage{
-md_compute_quantiles_share(welfare, weight, n_quantile = 10)
+md_compute_quantiles_share(welfare, weight, n_quantile = 10, lorenz = NULL)
 }
 \arguments{
 \item{welfare}{numeric: A vector of income or consumption values.}
@@ -12,8 +12,10 @@ md_compute_quantiles_share(welfare, weight, n_quantile = 10)
 \item{weight}{numeric: A vector of weights. Default is a vector of ones}
 
 \item{n_quantile}{numeric: Number of quantiles for which share of total income
-is desired. It can't be larger that the total number of percentiles in the
-Lorenz curve provided by the user.  default is 10.}
+is desired. Default is 10.}
+
+\item{lorenz}{numeric: A vector with the Lorenz curve percentiles. It can be computed
+using the function \code{md_compute_lorenz}}
 }
 \value{
 list

--- a/man/md_compute_quantiles_share.Rd
+++ b/man/md_compute_quantiles_share.Rd
@@ -4,7 +4,12 @@
 \alias{md_compute_quantiles_share}
 \title{Compute quantiles share}
 \usage{
-md_compute_quantiles_share(welfare, weight, n_quantile = 10, lorenz = NULL)
+md_compute_quantiles_share(
+  welfare,
+  weight = rep(1, length(welfare)),
+  n_quantile = 10,
+  lorenz = NULL
+)
 }
 \arguments{
 \item{welfare}{numeric: A vector of income or consumption values.}
@@ -14,8 +19,7 @@ md_compute_quantiles_share(welfare, weight, n_quantile = 10, lorenz = NULL)
 \item{n_quantile}{numeric: Number of quantiles for which share of total income
 is desired. Default is 10.}
 
-\item{lorenz}{numeric: A vector with the Lorenz curve percentiles. It can be computed
-using the function \code{md_compute_lorenz}}
+\item{lorenz}{numeric: Output from \code{md_compute_lorenz}}
 }
 \value{
 list

--- a/tests/testthat/test-md_compute_quantiles.R
+++ b/tests/testthat/test-md_compute_quantiles.R
@@ -176,4 +176,19 @@ test_that("md_compute_median() computations are correct", {
 
 })
 
+test_that("md_compute_median() takes lorenz argument", {
+  lz <- md_compute_lorenz(
+    welfare = df$welfare,
+    weight = df$weight,
+    nbins = 10
+  )
 
+  out <- md_compute_median(
+    lorenz = lz
+  )
+
+  expect_equal(length(out), 1)
+
+  expect_equal(out, 183.3333)
+
+})

--- a/tests/testthat/test-md_compute_quantiles.R
+++ b/tests/testthat/test-md_compute_quantiles.R
@@ -45,6 +45,31 @@ test_that("md_compute_quantiles_share() computations are correct", {
 
 })
 
+test_that("md_compute_quantiles_share() takes lorenz argument", {
+  lz <- md_compute_lorenz(
+    welfare = df$welfare,
+    weight = df$weight,
+    nbins = 10
+  )
+
+  out <- md_compute_quantiles_share(
+    lorenz = lz
+  )
+
+  expect_equal(out, c(0.005920027,
+                      0.016977475,
+                      0.024752993,
+                      0.033998374,
+                      0.045897644,
+                      0.057935898,
+                      0.075664645,
+                      0.104816656,
+                      0.165985703,
+                      0.468050586
+  ))
+
+})
+
 test_that("old_md_compute_quantiles() computations are correct", {
   out <- old_md_compute_quantiles(
     lwelfare   = md_lorenz1$lorenzY,
@@ -110,6 +135,34 @@ test_that("md_compute_quantiles() computations are correct", {
                )
 
 })
+
+test_that("md_compute_quantiles() takes lorenz argument", {
+  lz <- md_compute_lorenz(
+    welfare = df$welfare,
+    weight = df$weight,
+    nbins = 10
+  )
+
+  out <- md_compute_quantiles(
+    lorenz = lz
+  )
+
+  expect_equal(length(out), 10)
+
+  expect_equal(out, c(44.00000,
+                      73.33334,
+                      106.33330,
+                      139.33330,
+                      183.33330,
+                      233.75000,
+                      315.00000,
+                      445.50000,
+                      770.00000,
+                      169400.00000)
+  )
+
+})
+
 
 test_that("md_compute_median() computations are correct", {
   out <- md_compute_median(


### PR DESCRIPTION
I added parameter lorenz to quantile functions and change the median function to use lorenz. Also, fixed the default for weights. 
Things to consider: 
1. the lorenz parameter calls the output from md_quantile_lorenz, not the lorenz$welfare vector (Let me know if I should change it).
2. The median works with lorenz now, but it will give different results if the lorenz$welfare vector is even or uneven. 